### PR TITLE
Allow using a specific version number for $package_ensure

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -71,8 +71,10 @@ class rngd (
     validate_string($extra_options)
   }
 
-  validate_re($package_ensure, '^(present|installed|absent|latest)$',
-    'rngd::service_ensure must be present, installed, absent or latest.')
+  # workaround for different fixnum and float behaviour in Puppet 3.x and 4.x:
+  # convert $package_ensure to a string
+  validate_re("${package_ensure}", '^(present|installed|absent|latest|\d+.*)$', # lint:ignore:only_variable_string
+    'rngd::service_ensure must be present, installed, absent, latest or a specific version.')
 
   validate_re($service_ensure, '^(running|stopped)$',
     'rngd::service_ensure must be running or stopped.')

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -125,9 +125,9 @@ describe 'rngd' do
       },
       'regex_package_ensure' => {
         :name    => %w(package_ensure),
-        :valid   => %w(present installed absent latest),
-        :invalid => ['purged', 'held', 'invalid', %w(array), { 'ha' => 'sh' }, 3, 2.42, true, false, nil],
-        :message => 'must be present, installed, absent or latest',
+        :valid   => ['present', 'installed', 'absent', 'latest', '5', '5.01', 3, 2.42],
+        :invalid => ['purged', 'held', 'invalid', %w(array), { 'ha' => 'sh' }, true, false, nil],
+        :message => 'must be present, installed, absent, latest or a specific version',
       },
       'regex_service_ensure' => {
         :name    => %w(service_ensure),

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -131,7 +131,7 @@ describe 'rngd' do
       },
       'regex_service_ensure' => {
         :name    => %w(service_ensure),
-        :valid   => ['running', 'stopped'],
+        :valid   => %w(running stopped),
         :invalid => ['invalid', %w(array), { 'ha' => 'sh' }, 3, 2.42, nil, true],
         :message => 'must be running or stopped',
       },


### PR DESCRIPTION
This is needed to allow setting $package_ensure to a specific version number as mentioned in the readme. To also allow fixnums and floats as input, the validate_re() needs to stringify them like in [1]

[1] https://github.com/Phil-Friderici/puppet-rngd/commit/66a0814005479d97dabf26938db1c256d9070c25#diff-60ae41fd0a31977447947f59940ee9a4R88
